### PR TITLE
Update gfyObject.js

### DIFF
--- a/js/gfyObject.js
+++ b/js/gfyObject.js
@@ -137,6 +137,7 @@ var gfyObject = function (gfyElem) {
         gfyRootElem.style.padding = 0;
         if (!optExpand) {
             gfyRootElem.style.display = 'inline-block';
+            gfyRootElem.style.overflow = 'hidden';
             gfyRootElem.style.boxSizing = 'border-box';
             gfyRootElem.style.MozBoxSizing = 'border-box';
             gfyRootElem.style.webkitBoxSizing = 'border-box';


### PR DESCRIPTION
Added overflow hidden to the root element to prevent the initial canvas size getting in the way of resizing down eg. going from landscape to portrait.

Basically the canvas element doesn't resize along with the root element so there might be a better way to fix but this does the job for now.
