### PR TITLE
Modified so you can dynamically add content to the page and rescan for gfycats

### DIFF
--- a/js/gfyObject.js
+++ b/js/gfyObject.js
@@ -31,10 +31,6 @@ var gfyObject = function (gfyElem) {
     var gfyWidth;
     var gfyHeight;
 
-    // if there are are multiple copies of the same gfycat ID on the page, this 
-    // counter helps us tell them apart
-    gfyObject.unique = 0;
-
 
     // Helper function -- only required because some browsers do not have get by class name
     function byClass(className, obj) {
@@ -280,8 +276,9 @@ var gfyObject = function (gfyElem) {
     // used to load ajax info for each gfycat on the page
     // callback functions must be setup and uniquely named for each
     function loadJSONP(url, callback, context) {
+        var unique = Math.floor((Math.random()*10000000) + 1);
         // INIT
-        var name = "_" + gfyId + "_" + gfyObject.unique++;
+        var name = "_" + gfyId + "_" + unique++;
         if (url.match(/\?/)) url += "&callback=" + name;
         else url += "?callback=" + name;
 


### PR DESCRIPTION
In my case I let users write content which is added to the page dynamically, so I just call the new gfyCollection.scan() function after adding the content.  Before this, calling gfyCollection.init() twice would try to re-run gfyObject.init() for gfycats already caught in the previous scan.  Also changed the unique var to work the way I think it was supposed to originally, although it should not affect anything.
